### PR TITLE
READMEへのDB設計の記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## postsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
+|text|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
@@ -24,7 +24,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :posts
 - has many :users_groups

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 |------|----|-------|
 |email|string|null: false, unique: true|
 |password|string|null: false|
-|nickname|string|null: false|
+|nickname|string|null: false, index: true|
 ### Association
 - has_many :posts
 - has many :users_groups
@@ -15,8 +15,8 @@
 |------|----|-------|
 |text|text||
 |image|string||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group
@@ -33,8 +33,8 @@
 ## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 |nickname|string|null: false, index: true|
 ### Association
 - has_many :posts
-- has many :users_groups
-- has many :groups, through: :users_groups
+- has_many :users_groups
+- has_many :groups, through: :users_groups
 
 ## postsテーブル
 |Column|Type|Options|
@@ -27,8 +27,8 @@
 |name|string|null: false|
 ### Association
 - has_many :posts
-- has many :users_groups
-- has many :users, through: :users_groups
+- has_many :users_groups
+- has_many :users, through: :users_groups
 
 ## users_groupsテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# README
+# ChatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+|nickname|string|null: false|
+### Association
+- has_many :posts
+- has many :users_groups
+- has many :groups, through: :users_groups
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## postsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
 
-Things you may want to cover:
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+### Association
+- has_many :posts
+- has many :users_groups
+- has many :users, through: :users_groups
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## users_groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group


### PR DESCRIPTION
# What
chat-spaceのDB設計をreadmeに記述した。テーブルはusersテーブル、postsテーブル、groupsテーブル、
users-groupsテーブルがある。

# why
##  usersテーブル
　このテーブルには名前、メールアドレス、パスワードのカラムが必要と判断した。全てのカラムにNOT NULL制約、また、メールアドレスカラムには一意性制約が必要と判断した。

　アソシエーションは、usersテーブル対postsテーブル、usersテーブル対users-groupsテーブルで一対多の関係、usersテーブル対groupsテーブルでusers-groupsテーブルを経由して一対多の関係である。
## postsテーブル
　このテーブルにはテキストと画像のカラムが必要と判断した。テキストは必ず投稿するのでNOT NULL制約が必要であるが、画像は必ずしも投稿する必要がないと判断し、NOT NULL制約は付けなかった。
　投稿されたものは必ず投稿者とグループに帰属しているので、外部キーとしてuser_idとgroup_idを設定した、またidは必要なのでNOT NULL制約が必要と判断した。

　アソシエーションは、postsテーブル対usersテーブル、postsテーブル対groupsテーブル、で一対一の関係である。
## groupsテーブル
　このテーブルにはグループ名が必要と判断した。グループ名は必ず記入するのでNOT NULL制約が必要であると判断した。

　アソシエーションはgroupsテーブル対postsテーブル、groupsテーブ対users-groupsテーブルで一対多の関係、groupsテーブル対usersテーブルでusers-groupsテーブルを経由して一対多の関係である。
## users-groupsテーブル
　このテーブルには外部キーとしてuser_idとgroup_idを設定し、またidは必要なのでNOT NULL制約が必要と判断した。

　アソシエーションとしてusers-groupsテーブル対usersテーブル、users-groupsテーブル対groupsテーブルで一対一の関係である。